### PR TITLE
feat: add pre-commit-autoupdate hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,17 +25,21 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/markdownlint/markdownlint
-    rev: v0.12.0
+    rev: v0.15.0
     hooks:
       - id: markdownlint_docker
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.8
+    rev: v1.7.9
     hooks:
       - id: actionlint-docker
   - repo: https://github.com/bridgecrewio/checkov
-    rev: 3.2.494
+    rev: 3.2.495
     hooks:
       - id: checkov_container
+  - repo: https://github.com/mosher-labs/pre-commit-autoupdate
+    rev: v1.0.0
+    hooks:
+      - id: autoupdate
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.3.0
     hooks:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,8 @@ basic-repo-template/
 - `refactor:` - Code refactoring (no version bump)
 - `test:` - Temporary test changes (like branch references)
 
-**Breaking changes:** Add `!` after type (e.g., `feat!:`) or include `BREAKING CHANGE:` in commit body for major version bump
+**Breaking changes:** Add `!` after type (e.g., `feat!:`) or include
+`BREAKING CHANGE:` in commit body for major version bump
 
 ## Pre-commit Hooks
 


### PR DESCRIPTION
## Summary

- Add the `pre-commit-autoupdate` hook to automatically keep all pre-commit hooks up to date on every commit
- Update existing hooks to their latest versions (markdownlint, actionlint, checkov)
- Fix markdown lint issue in CLAUDE.md (line length)

## Test plan

- [ ] Verify CI passes
- [ ] Test the autoupdate hook runs on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)